### PR TITLE
Added tests to the Dragons features

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
   "presets": ["@babel/preset-react"],
-  "plugins": ["@babel/plugin-syntax-jsx"]
+  "plugins": ["@babel/plugin-syntax-jsx"],
+  "env": {
+    "test": {
+      "plugins": ["@babel/plugin-transform-modules-commonjs"]
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@babel/core": "^7.18.5",
         "@babel/eslint-parser": "^7.18.2",
         "@babel/plugin-syntax-jsx": "^7.17.12",
+        "@babel/plugin-transform-modules-commonjs": "^7.18.2",
         "@babel/preset-react": "^7.17.12",
         "@testing-library/react": "^13.3.0",
         "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "jest --watch",
+    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "jest --watch",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -47,6 +47,7 @@
     "@babel/core": "^7.18.5",
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-syntax-jsx": "^7.17.12",
+    "@babel/plugin-transform-modules-commonjs": "^7.18.2",
     "@babel/preset-react": "^7.17.12",
     "@testing-library/react": "^13.3.0",
     "eslint": "^7.32.0",

--- a/src/components/dragons/__snapshots__/dragons.test.js.snap
+++ b/src/components/dragons/__snapshots__/dragons.test.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The Dragons page component should mantain the snapshot between renders 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <ul />
+    </div>
+  </body>,
+  "container": <div>
+    <ul />
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/components/dragons/dragons.test.js
+++ b/src/components/dragons/dragons.test.js
@@ -88,9 +88,9 @@ describe('The Dragons page component', () => {
     });
   });
 
-  it("should mantain the snapshot between renders", async () => {
+  it('should mantain the snapshot between renders', async () => {
     const dom = render(<Provider store={store}><Dragons /></Provider>);
 
     await act(() => expect(dom).toMatchSnapshot());
-  })
+  });
 });

--- a/src/components/dragons/dragons.test.js
+++ b/src/components/dragons/dragons.test.js
@@ -3,6 +3,7 @@ import {
 } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import Dragons from './Dragons';
+import MyProfile from '../my-profile/MyProfile';
 import store from '../../redux/configureStore';
 import axios from '../../http-common';
 
@@ -69,4 +70,11 @@ describe('The Dragons page component', () => {
     const buttons = await screen.findAllByText('Reserve Dragon');
     expect(buttons.length).toBe(2);
   });
+
+  test("that there are no reserved dragons at first MyProfile page component render", async () => {
+    render(<Provider store={store}><MyProfile /></Provider>);
+    await waitFor(() => {
+      expect(screen.queryByText('You don\'t have dragon reservations yet.')).not.toBeNull()
+    });
+  })
 });

--- a/src/components/dragons/dragons.test.js
+++ b/src/components/dragons/dragons.test.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import Dragons from './Dragons';
 import store from '../../redux/configureStore';
@@ -32,16 +32,20 @@ describe("The Dragons page component", () => {
 
   it("should render the page", async () => {
     render(<Provider store={store}><Dragons /></Provider>)
-    await waitFor(() => expect(screen.getAllByText('Reserve Dragon').length).toBeGreaterThan(0));
+    await waitFor(() => {
+      expect(screen.getAllByText('Reserve Dragon').length).toBeGreaterThan(0);
+    });
+
   });
 
   it("becomes a reserved dragon after a user clicks its reserve button", async () => {
     render(<Provider store={store}><Dragons /></Provider>);
-    await waitFor(() => {
-      const buttons = screen.queryAllByText('Reserve Dragon');
-      fireEvent.click(buttons[0]);
-    });
+    const buttons = await screen.findAllByText('Reserve Dragon');
+    fireEvent.click(buttons[0]);
 
-    await waitFor(() => expect(screen.getAllByText('Reserved').length).toBe(1));
-  })
+    const reserved = await screen.findAllByText('Reserved')
+    const cancelButtons = await screen.findAllByText('Cancel Reservation')
+    expect(reserved.length).toBe(1);
+    expect(cancelButtons.length).toBe(1);
+  });
 })

--- a/src/components/dragons/dragons.test.js
+++ b/src/components/dragons/dragons.test.js
@@ -1,0 +1,38 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import Dragons from './Dragons';
+import store from '../../redux/configureStore';
+import axios from '../../http-common'
+jest.mock('../../http-common');
+
+describe("The Dragons page component", () => {
+  beforeEach(async () => {
+    const resp = {
+      data: [
+        {
+          "id": "dragon1",
+          "name": "Dragon 1",
+          "type": "capsule",
+          "flickr_images": [
+            "https://i.imgur.com/9fWdwNv.jpg",
+          ],
+        },
+        {
+          "id": "dragon2",
+          "name": "Dragon 2",
+          "type": "capsule",
+          "flickr_images": [
+            "https://farm8.staticflickr.com/7647/16581815487_6d56cb32e1_b.jpg",
+          ],
+        }
+      ]
+    };
+    await axios.get.mockResolvedValue(resp)
+  });
+
+  it("should render the page", async () => {
+    render(<Provider store={store}><Dragons /></Provider>)
+    await waitFor(() => expect(screen.getAllByText('Reserve Dragon').length).toBeGreaterThan(0));
+  });
+
+})

--- a/src/components/dragons/dragons.test.js
+++ b/src/components/dragons/dragons.test.js
@@ -35,4 +35,13 @@ describe("The Dragons page component", () => {
     await waitFor(() => expect(screen.getAllByText('Reserve Dragon').length).toBeGreaterThan(0));
   });
 
+  it("becomes a reserved dragon after a user clicks its reserve button", async () => {
+    render(<Provider store={store}><Dragons /></Provider>);
+    await waitFor(() => {
+      const buttons = screen.queryAllByText('Reserve Dragon');
+      fireEvent.click(buttons[0]);
+    });
+
+    await waitFor(() => expect(screen.getAllByText('Reserved').length).toBe(1));
+  })
 })

--- a/src/components/dragons/dragons.test.js
+++ b/src/components/dragons/dragons.test.js
@@ -71,6 +71,16 @@ describe('The Dragons page component', () => {
     expect(buttons.length).toBe(2);
   });
 
+  test("that there is a reserved dragon after making a reservation", async () => {
+    const { unmount } = render(<Provider store={store}><Dragons /></Provider>);
+    const reserveButtons = await screen.findAllByText('Reserve Dragon');
+    fireEvent.click(reserveButtons[0]);
+    unmount();
+
+    render(<Provider store={store}><MyProfile /></Provider>);
+    expect(screen.queryByText('Dragon 1')).not.toBeNull();
+  })
+
   test("that there are no reserved dragons at first MyProfile page component render", async () => {
     render(<Provider store={store}><MyProfile /></Provider>);
     await waitFor(() => {

--- a/src/components/dragons/dragons.test.js
+++ b/src/components/dragons/dragons.test.js
@@ -1,62 +1,64 @@
-import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import {
+  render, screen, waitFor, fireEvent, act,
+} from '@testing-library/react';
 import { Provider } from 'react-redux';
 import Dragons from './Dragons';
 import store from '../../redux/configureStore';
-import axios from '../../http-common'
+import axios from '../../http-common';
+
 jest.mock('../../http-common');
 
-describe("The Dragons page component", () => {
+describe('The Dragons page component', () => {
   beforeEach(async () => {
     const resp = {
       data: [
         {
-          "id": "dragon1",
-          "name": "Dragon 1",
-          "type": "capsule",
-          "flickr_images": [
-            "https://i.imgur.com/9fWdwNv.jpg",
+          id: 'dragon1',
+          name: 'Dragon 1',
+          type: 'capsule',
+          flickr_images: [
+            'https://i.imgur.com/9fWdwNv.jpg',
           ],
         },
         {
-          "id": "dragon2",
-          "name": "Dragon 2",
-          "type": "capsule",
-          "flickr_images": [
-            "https://farm8.staticflickr.com/7647/16581815487_6d56cb32e1_b.jpg",
+          id: 'dragon2',
+          name: 'Dragon 2',
+          type: 'capsule',
+          flickr_images: [
+            'https://farm8.staticflickr.com/7647/16581815487_6d56cb32e1_b.jpg',
           ],
-        }
-      ]
+        },
+      ],
     };
-    await axios.get.mockResolvedValue(resp)
+    await axios.get.mockResolvedValue(resp);
   });
 
   afterEach(() => {
-    store.dispatch({
-      type: "spacehub/dragons/DRAGONS_FETCHED",
+    act(() => store.dispatch({
+      type: 'spacehub/dragons/DRAGONS_FETCHED',
       payload: [],
-    });
+    }));
   });
 
-  it("should render the page", async () => {
-    render(<Provider store={store}><Dragons /></Provider>)
+  it('should render the page', async () => {
+    render(<Provider store={store}><Dragons /></Provider>);
     await waitFor(() => {
       expect(screen.getAllByText('Reserve Dragon').length).toBeGreaterThan(0);
     });
-
   });
 
-  it("becomes a reserved dragon after a user clicks its reserve button", async () => {
+  it('becomes a reserved dragon after a user clicks its reserve button', async () => {
     render(<Provider store={store}><Dragons /></Provider>);
     const buttons = await screen.findAllByText('Reserve Dragon');
     fireEvent.click(buttons[0]);
 
-    const reservedBadge = await screen.findAllByText('Reserved')
-    const cancelButtons = await screen.findAllByText('Cancel Reservation')
+    const reservedBadge = await screen.findAllByText('Reserved');
+    const cancelButtons = await screen.findAllByText('Cancel Reservation');
     expect(reservedBadge.length).toBe(1);
     expect(cancelButtons.length).toBe(1);
   });
 
-  it("should cancel a reservation when the user clicks the cancel reservation button", async () => {
+  it('should cancel a reservation when the user clicks the cancel reservation button', async () => {
     render(<Provider store={store}><Dragons /></Provider>);
     const reserveButtons = await screen.findAllByText('Reserve Dragon');
     fireEvent.click(reserveButtons[0]);
@@ -65,7 +67,6 @@ describe("The Dragons page component", () => {
     fireEvent.click(cancelButtons[0]);
 
     const buttons = await screen.findAllByText('Reserve Dragon');
-
-    expect(buttons.length).toBe(2)
-  })
-})
+    expect(buttons.length).toBe(2);
+  });
+});

--- a/src/components/dragons/dragons.test.js
+++ b/src/components/dragons/dragons.test.js
@@ -71,7 +71,7 @@ describe('The Dragons page component', () => {
     expect(buttons.length).toBe(2);
   });
 
-  test("that there is a reserved dragon after making a reservation", async () => {
+  test('that there is a reserved dragon after making a reservation', async () => {
     const { unmount } = render(<Provider store={store}><Dragons /></Provider>);
     const reserveButtons = await screen.findAllByText('Reserve Dragon');
     fireEvent.click(reserveButtons[0]);
@@ -79,12 +79,12 @@ describe('The Dragons page component', () => {
 
     render(<Provider store={store}><MyProfile /></Provider>);
     expect(screen.queryByText('Dragon 1')).not.toBeNull();
-  })
+  });
 
-  test("that there are no reserved dragons at first MyProfile page component render", async () => {
+  test('that there are no reserved dragons at first MyProfile page component render', async () => {
     render(<Provider store={store}><MyProfile /></Provider>);
     await waitFor(() => {
-      expect(screen.queryByText('You don\'t have dragon reservations yet.')).not.toBeNull()
+      expect(screen.queryByText('You don\'t have dragon reservations yet.')).not.toBeNull();
     });
-  })
+  });
 });

--- a/src/components/dragons/dragons.test.js
+++ b/src/components/dragons/dragons.test.js
@@ -30,6 +30,13 @@ describe("The Dragons page component", () => {
     await axios.get.mockResolvedValue(resp)
   });
 
+  afterEach(() => {
+    store.dispatch({
+      type: "spacehub/dragons/DRAGONS_FETCHED",
+      payload: [],
+    });
+  });
+
   it("should render the page", async () => {
     render(<Provider store={store}><Dragons /></Provider>)
     await waitFor(() => {
@@ -43,9 +50,22 @@ describe("The Dragons page component", () => {
     const buttons = await screen.findAllByText('Reserve Dragon');
     fireEvent.click(buttons[0]);
 
-    const reserved = await screen.findAllByText('Reserved')
+    const reservedBadge = await screen.findAllByText('Reserved')
     const cancelButtons = await screen.findAllByText('Cancel Reservation')
-    expect(reserved.length).toBe(1);
+    expect(reservedBadge.length).toBe(1);
     expect(cancelButtons.length).toBe(1);
   });
+
+  it("should cancel a reservation when the user clicks the cancel reservation button", async () => {
+    render(<Provider store={store}><Dragons /></Provider>);
+    const reserveButtons = await screen.findAllByText('Reserve Dragon');
+    fireEvent.click(reserveButtons[0]);
+
+    const cancelButtons = await screen.findAllByText('Cancel Reservation');
+    fireEvent.click(cancelButtons[0]);
+
+    const buttons = await screen.findAllByText('Reserve Dragon');
+
+    expect(buttons.length).toBe(2)
+  })
 })

--- a/src/components/dragons/dragons.test.js
+++ b/src/components/dragons/dragons.test.js
@@ -87,4 +87,10 @@ describe('The Dragons page component', () => {
       expect(screen.queryByText('You don\'t have dragon reservations yet.')).not.toBeNull();
     });
   });
+
+  it("should mantain the snapshot between renders", async () => {
+    const dom = render(<Provider store={store}><Dragons /></Provider>);
+
+    await act(() => expect(dom).toMatchSnapshot());
+  })
 });


### PR DESCRIPTION
#### In this PR I have added tests to the `Dragons` page component as well as tested that the reserved dragons appear on `MyProfile` page component.

#### In this PR I have:
- [x] Added tests for the `Dragons` page component that tests the entire redux store associated with this feature, including the every individual `Dragon` component
- [x] Added tests to verify user interactivity when clicking the _Reserve Dragon_ button
- [x] Added tests to verify that a reservation is canceled when a user clicks the _Cancel Reservation_ button
- [x] Tested that a _Reserved_ badge appears when the user clicks the _Reserve Dragon_ button
- [x] Added tests to verify there are no reserved dragons on `MyProfile` page component at the first render (meaning when the user navigates directly to /profile)
- [x] Added test to verify that the reserved dragons appear on `MyProfile` after making reservations.   
- [x] Fixed linter errors