### PR TITLE
Rockets tests - Testing all functionality for rockets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
   "presets": ["@babel/preset-react"],
-  "plugins": ["@babel/plugin-syntax-jsx"]
+  "plugins": ["@babel/plugin-syntax-jsx"],
+  "env": {
+    "test": {
+      "plugins": ["@babel/plugin-transform-modules-commonjs"]
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "space-travelers-hub",
       "version": "0.1.0",
       "dependencies": {
+        "@babel/plugin-transform-modules-commonjs": "^7.18.2",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^0.27.2",
@@ -21112,6 +21113,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -37575,6 +37589,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+      "peer": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@babel/plugin-transform-modules-commonjs": "^7.18.2",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^0.27.2",

--- a/src/components/rockets/Rockets.test.js
+++ b/src/components/rockets/Rockets.test.js
@@ -11,33 +11,35 @@ jest.mock('../../http-common');
 
 describe('Rockets Component', () => {
   beforeEach(async () => {
-    const state = {data: [
-      {
-        id: 1,
-        name: 'Falcon 1',
-        description: 'fast',
-        flickr_images: ["https://imgur.com/DaCfMsj.jpg"],
-      },
-      {
-        id: 2,
-        name: 'Falcon 9',
-        description: 'more fast',
-        flickr_images: ["https://farm1.staticflickr.com/929/28787338307_3453a11a77_b.jpg"],
-      },
-      {
-        id: 3,
-        name: 'Falcon Heavy',
-        description: 'even more fast',
-        flickr_images: ["https://farm5.staticflickr.com/4599/38583829295_581f34dd84_b.jpg"],
-      },
-      {
-        id: 4,
-        name: 'Starship',
-        description: 'fast fast',
-        flickr_images: ["https://live.staticflickr.com/65535/48954138962_ee541e6755_b.jpg"],
-      }
-      
-    ]};
+    const state = {
+      data: [
+        {
+          id: 1,
+          name: 'Falcon 1',
+          description: 'fast',
+          flickr_images: ['https://imgur.com/DaCfMsj.jpg'],
+        },
+        {
+          id: 2,
+          name: 'Falcon 9',
+          description: 'more fast',
+          flickr_images: ['https://farm1.staticflickr.com/929/28787338307_3453a11a77_b.jpg'],
+        },
+        {
+          id: 3,
+          name: 'Falcon Heavy',
+          description: 'even more fast',
+          flickr_images: ['https://farm5.staticflickr.com/4599/38583829295_581f34dd84_b.jpg'],
+        },
+        {
+          id: 4,
+          name: 'Starship',
+          description: 'fast fast',
+          flickr_images: ['https://live.staticflickr.com/65535/48954138962_ee541e6755_b.jpg'],
+        },
+
+      ],
+    };
     await axios.get.mockResolvedValue(state);
   });
 
@@ -49,7 +51,7 @@ describe('Rockets Component', () => {
   });
 
   it('renders correctly', async () => {
-    render(<Provider store={store}><Rockets/></Provider>);
+    render(<Provider store={store}><Rockets /></Provider>);
     await waitFor(() => {
       expect(screen.getAllByText('Reserve Rocket').length).toBeGreaterThan(0);
     });
@@ -76,7 +78,7 @@ describe('Rockets Component', () => {
   });
 
   it('renders no reserved rockets on first load of profile', async () => {
-    render(<Provider store={store}><MyProfile/></Provider>);
+    render(<Provider store={store}><MyProfile /></Provider>);
     expect(screen.findByText('You have no reserved rockets')).toBeTruthy();
   });
 
@@ -84,7 +86,7 @@ describe('Rockets Component', () => {
     render(<Provider store={store}><Rockets /></Provider>);
     const reserveBtns = await screen.findAllByText('Reserve Rocket');
     fireEvent.click(reserveBtns[0]);
-    render(<Provider store={store}><MyProfile/></Provider>);
+    render(<Provider store={store}><MyProfile /></Provider>);
     expect(screen.findByText('Falcon 1')).toBeTruthy();
   });
 
@@ -92,19 +94,18 @@ describe('Rockets Component', () => {
     render(<Provider store={store}><Rockets /></Provider>);
     const reserveBtns = await screen.findAllByText('Reserve Rocket');
     fireEvent.click(reserveBtns[0]);
-    render(<Provider store={store}><MyProfile/></Provider>);
+    render(<Provider store={store}><MyProfile /></Provider>);
     expect(screen.findByText('Falcon 1')).toBeTruthy();
 
     render(<Provider store={store}><Rockets /></Provider>);
     const cancelResBtns = await screen.findAllByText('Cancel Reservation');
     fireEvent.click(cancelResBtns[0]);
-    render(<Provider store={store}><MyProfile/></Provider>);
+    render(<Provider store={store}><MyProfile /></Provider>);
     expect(screen.findByText('You have no reserved rockets')).toBeTruthy();
   });
 
   it('maintains the snapshots between renders', async () => {
-    const tree = render(<Provider store={store}><Rockets/></Provider>);
+    const tree = render(<Provider store={store}><Rockets /></Provider>);
     await expect(tree).toMatchSnapshot();
   });
 });
-

--- a/src/components/rockets/Rockets.test.js
+++ b/src/components/rockets/Rockets.test.js
@@ -62,5 +62,10 @@ describe('Rockets Component', () => {
     const reservedBadges = await screen.findAllByText('Reserved');
     expect(reservedBadges.length).toBeGreaterThan(0);
   });
+
+  it('maintains the snapshots between renders', async () => {
+    const tree = render(<Provider store={store}><Rockets/></Provider>);
+    await act(() => expect(tree).toMatchSnapshot());
+  });
 });
 

--- a/src/components/rockets/Rockets.test.js
+++ b/src/components/rockets/Rockets.test.js
@@ -75,6 +75,11 @@ describe('Rockets Component', () => {
     expect(reserveBtns.length).toStrictEqual(4);
   });
 
+  it('renders no reserved rockets on first load of profile', async () => {
+    render(<Provider store={store}><MyProfile/></Provider>);
+    expect(screen.findByText('You have no reserved rockets')).toBeTruthy();
+  });
+
   it('maintains the snapshots between renders', async () => {
     const tree = render(<Provider store={store}><Rockets/></Provider>);
     await act(() => expect(tree).toMatchSnapshot());

--- a/src/components/rockets/Rockets.test.js
+++ b/src/components/rockets/Rockets.test.js
@@ -54,5 +54,13 @@ describe('Rockets Component', () => {
       expect(screen.getAllByText('Reserve Rocket').length).toBeGreaterThan(0);
     });
   });
+
+  it('reserves a rocket on clicking the reserve button', async () => {
+    render(<Provider store={store}><Rockets /></Provider>);
+    const reserveBtns = await screen.findAllByText('Reserve Rocket');
+    fireEvent.click(reserveBtns[0]);
+    const reservedBadges = await screen.findAllByText('Reserved');
+    expect(reservedBadges.length).toBeGreaterThan(0);
+  });
 });
 

--- a/src/components/rockets/Rockets.test.js
+++ b/src/components/rockets/Rockets.test.js
@@ -80,6 +80,28 @@ describe('Rockets Component', () => {
     expect(screen.findByText('You have no reserved rockets')).toBeTruthy();
   });
 
+  it('reserves rockets and appear in the profile', async () => {
+    render(<Provider store={store}><Rockets /></Provider>);
+    const reserveBtns = await screen.findAllByText('Reserve Rocket');
+    fireEvent.click(reserveBtns[0]);
+    render(<Provider store={store}><MyProfile/></Provider>);
+    expect(screen.findByText('Falcon 1')).toBeTruthy();
+  });
+
+  it('reserves rockets that appear in the profile, then cancels and the profile is emptied', async () => {
+    render(<Provider store={store}><Rockets /></Provider>);
+    const reserveBtns = await screen.findAllByText('Reserve Rocket');
+    fireEvent.click(reserveBtns[0]);
+    render(<Provider store={store}><MyProfile/></Provider>);
+    expect(screen.findByText('Falcon 1')).toBeTruthy();
+
+    render(<Provider store={store}><Rockets /></Provider>);
+    const cancelResBtns = await screen.findAllByText('Cancel Reservation');
+    fireEvent.click(cancelResBtns[0]);
+    render(<Provider store={store}><MyProfile/></Provider>);
+    expect(screen.findByText('You have no reserved rockets')).toBeTruthy();
+  });
+
   it('maintains the snapshots between renders', async () => {
     const tree = render(<Provider store={store}><Rockets/></Provider>);
     await act(() => expect(tree).toMatchSnapshot());

--- a/src/components/rockets/Rockets.test.js
+++ b/src/components/rockets/Rockets.test.js
@@ -1,5 +1,5 @@
 import {
-  render, screen, waitFor, fireEvent, act,
+  render, screen, waitFor, fireEvent,
 } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import Rockets from './Rockets';
@@ -42,10 +42,10 @@ describe('Rockets Component', () => {
   });
 
   afterEach(() => {
-    act(() => store.dispatch({
+    store.dispatch({
       type: 'spacehub/rockets/ADD_ALL_ROCKETS',
       payload: [],
-    }));
+    });
   });
 
   it('renders correctly', async () => {
@@ -104,7 +104,7 @@ describe('Rockets Component', () => {
 
   it('maintains the snapshots between renders', async () => {
     const tree = render(<Provider store={store}><Rockets/></Provider>);
-    await act(() => expect(tree).toMatchSnapshot());
+    await expect(tree).toMatchSnapshot();
   });
 });
 

--- a/src/components/rockets/Rockets.test.js
+++ b/src/components/rockets/Rockets.test.js
@@ -63,6 +63,18 @@ describe('Rockets Component', () => {
     expect(reservedBadges.length).toBeGreaterThan(0);
   });
 
+  it('cancels a reserved rocket on clicking the cancel reservation button', async () => {
+    render(<Provider store={store}><Rockets /></Provider>);
+    let reserveBtns = await screen.findAllByText('Reserve Rocket');
+    fireEvent.click(reserveBtns[0]);
+    const reservedBadges = await screen.findAllByText('Reserved');
+    expect(reservedBadges.length).toStrictEqual(1);
+    const cancelResBtns = await screen.findAllByText('Cancel Reservation');
+    fireEvent.click(cancelResBtns[0]);
+    reserveBtns = await screen.findAllByText('Reserve Rocket');
+    expect(reserveBtns.length).toStrictEqual(4);
+  });
+
   it('maintains the snapshots between renders', async () => {
     const tree = render(<Provider store={store}><Rockets/></Provider>);
     await act(() => expect(tree).toMatchSnapshot());

--- a/src/components/rockets/Rockets.test.js
+++ b/src/components/rockets/Rockets.test.js
@@ -1,0 +1,58 @@
+import {
+  render, screen, waitFor, fireEvent, act,
+} from '@testing-library/react';
+import { Provider } from 'react-redux';
+import Rockets from './Rockets';
+import MyProfile from '../my-profile/MyProfile';
+import store from '../../redux/configureStore';
+import axios from '../../http-common';
+
+jest.mock('../../http-common');
+
+describe('Rockets Component', () => {
+  beforeEach(async () => {
+    const state = {data: [
+      {
+        id: 1,
+        name: 'Falcon 1',
+        description: 'fast',
+        flickr_images: ["https://imgur.com/DaCfMsj.jpg"],
+      },
+      {
+        id: 2,
+        name: 'Falcon 9',
+        description: 'more fast',
+        flickr_images: ["https://farm1.staticflickr.com/929/28787338307_3453a11a77_b.jpg"],
+      },
+      {
+        id: 3,
+        name: 'Falcon Heavy',
+        description: 'even more fast',
+        flickr_images: ["https://farm5.staticflickr.com/4599/38583829295_581f34dd84_b.jpg"],
+      },
+      {
+        id: 4,
+        name: 'Starship',
+        description: 'fast fast',
+        flickr_images: ["https://live.staticflickr.com/65535/48954138962_ee541e6755_b.jpg"],
+      }
+      
+    ]};
+    await axios.get.mockResolvedValue(state);
+  });
+
+  afterEach(() => {
+    act(() => store.dispatch({
+      type: 'spacehub/rockets/ADD_ALL_ROCKETS',
+      payload: [],
+    }));
+  });
+
+  it('renders correctly', async () => {
+    render(<Provider store={store}><Rockets/></Provider>);
+    await waitFor(() => {
+      expect(screen.getAllByText('Reserve Rocket').length).toBeGreaterThan(0);
+    });
+  });
+});
+

--- a/src/components/rockets/__snapshots__/Rockets.test.js.snap
+++ b/src/components/rockets/__snapshots__/Rockets.test.js.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rockets Component maintains the snapshots between renders 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="rockets"
+      >
+        <ul
+          class="rocket-list"
+        />
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="rockets"
+    >
+      <ul
+        class="rocket-list"
+      />
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;


### PR DESCRIPTION
In this PR I:

- [x] Added the tests for the `Rockets` component.
- [x] Tested:
       - Rendering
       - Maintained snapshot
       - Reserve rocket
       - Cancel reserved rocket
       - Show empty profile on first load
       - Show reserved rocket on profile
       - Show reserved rocket on profile, then cancel and show empty profile